### PR TITLE
Fixed accessing the extended attributes (i.e. ASN)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rgeolocate
 Type: Package
 Title: IP Address Geolocation
-Version: 1.4.2
+Version: 1.4.3
 Date: 2021-12-18
 Author: Os Keyes [aut, cre], Drew Schmidt [aut], David Robinson [ctb],
     Chris Davis [ctb], Bob Rudis [ctb], Maxmind, Inc. [cph], Pascal Gloor [cph], IP2Location.com [cph]

--- a/R/maxmind.R
+++ b/R/maxmind.R
@@ -24,6 +24,7 @@
 #'  \item{asn}{: Autonomous System Number. Requires an ISP database.}
 #'  \item{aso}{: Autonomous System Organization. Requires an ISP database.}
 #'  \item{connection}{: the type of internet connection. Requires a connection type/netspeed database.}
+#'  \item{user_type}{: the type of organization, i.e. Hosting, Corporate. Requires an ISP database.}
 #'}
 #'@details
 #'\code{geolookup} uses the \href{https://dev.maxmind.com/geoip/geoip2/downloadable/}{MaxMind GeoIP2 databases}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -3,7 +3,7 @@ rgeo_env <- new.env(parent = emptyenv())
 .onLoad <- function(...) {
   maxmind_tags <- c("continent_name", "country_name", "country_code", "region_name",
                     "city_name", "timezone", "connection", "city_geoname_id", "latitude", "longitude",
-                    "isp", "organization", "asn", "aso", "postcode","city_metro_code")
+                    "isp", "organization", "asn", "aso", "postcode","city_metro_code", "user_type")
   ipinfo_tags <- c("hostname", "city", "region", "country",
                    "loc", "org", "postal", "phone")
   

--- a/src/maxmind.cpp
+++ b/src/maxmind.cpp
@@ -175,23 +175,23 @@ CharacterVector maxmind_bindings::postcode(MMDB_s *data, CharacterVector ip_addr
 }
 
 CharacterVector maxmind_bindings::connection(MMDB_s *data, CharacterVector ip_addresses){
-  return mmdb_getstring(data, ip_addresses, "connection_type", NULL);
+  return mmdb_getstring(data, ip_addresses, "traits", "connection_type", NULL);
 }
 
 CharacterVector maxmind_bindings::isp(MMDB_s *data, CharacterVector ip_addresses){
-  return mmdb_getstring(data, ip_addresses, "isp", NULL);
+  return mmdb_getstring(data, ip_addresses, "traits", "isp", NULL);
 }
 
 CharacterVector maxmind_bindings::organization(MMDB_s *data, CharacterVector ip_addresses){
-  return mmdb_getstring(data, ip_addresses, "organization", NULL);
+  return mmdb_getstring(data, ip_addresses, "traits", "organization", NULL);
 }
 
 IntegerVector maxmind_bindings::asn(MMDB_s *data, CharacterVector ip_addresses){
-  return mmdb_getint32(data, ip_addresses, "autonomous_system_number", NULL);
+  return mmdb_getint32(data, ip_addresses, "traits", "autonomous_system_number", NULL);
 }
 
 CharacterVector maxmind_bindings::aso(MMDB_s *data, CharacterVector ip_addresses){
-  return mmdb_getstring(data, ip_addresses, "autonomous_system_organization", NULL);
+  return mmdb_getstring(data, ip_addresses, "traits", "autonomous_system_organization", NULL);
 }
 
 IntegerVector maxmind_bindings::city_geoname_id(MMDB_s *data, CharacterVector ip_addresses){
@@ -208,6 +208,10 @@ NumericVector maxmind_bindings::latitude(MMDB_s *data, CharacterVector ip_addres
 
 NumericVector maxmind_bindings::longitude(MMDB_s *data, CharacterVector ip_addresses){
   return mmdb_getdouble(data, ip_addresses, "location", "longitude", NULL);
+}
+
+CharacterVector maxmind_bindings::user_type(MMDB_s *data, CharacterVector ip_addresses){
+  return mmdb_getstring(data, ip_addresses, "traits", "user_type", NULL);
 }
 
 List maxmind_bindings::lookup(CharacterVector ip_addresses, MMDB_s *mmdb_set,
@@ -249,6 +253,8 @@ List maxmind_bindings::lookup(CharacterVector ip_addresses, MMDB_s *mmdb_set,
       output.push_back(city_geoname_id(mmdb_set, ip_addresses));
     } else if (fields[i] == "city_metro_code") {
       output.push_back(city_metro_code(mmdb_set, ip_addresses));
+    } else if (fields[i] == "user_type") {
+      output.push_back(user_type(mmdb_set, ip_addresses));
     }
     
   }

--- a/src/maxmind.h
+++ b/src/maxmind.h
@@ -44,6 +44,8 @@ private:
 
   NumericVector longitude(MMDB_s *data, CharacterVector ip_addresses);
   
+  CharacterVector user_type(MMDB_s *data, CharacterVector ip_addresses);
+
   List lookup(CharacterVector ip_addresses, MMDB_s *mmdb_set, std::vector < std::string > fields);
   
 public:


### PR DESCRIPTION
This has only been tested with a commercial MMDB from DB-IP.com

```
ip <- "43.131.30.179"

geo <- rgeolocate::maxmind(
     ip,
     geoip_file,
     fields = c(
         "continent_name",
         "country_code",
         "country_name",
         "region_name",
         "city_name",
         "latitude",
         "longitude",
         "timezone",
         "postcode",
         "isp",
         "organization",
         "asn",
         "aso",
         "connection",
         "user_type"
     )
 )
> geo
  continent_name country_code country_name region_name         city_name latitude
1         Europe           DE      Germany       Hesse Frankfurt am Main  50.1109
  longitude      timezone postcode              isp organization    asn
1   8.68213 Europe/Berlin    60313 Aceville Pte.ltd         <NA> 132203
                                                aso connection user_type
1 Shenzhen Tencent Computer Systems Company Limited  Corporate   hosting
```

This is still dependent on the data quality - for example 'Organisation' is missing for this IP address, but I have seen it for other records.